### PR TITLE
Fix dbus assert

### DIFF
--- a/io.mgba.mGBA.json
+++ b/io.mgba.mGBA.json
@@ -13,7 +13,9 @@
     "--socket=pulseaudio",
     "--socket=x11",
     "--env=QT_QPA_PLATFORM=flatpak",
-    "--env=QT_QPA_FLATPAK_PLATFORM=xcb"
+    "--env=QT_QPA_FLATPAK_PLATFORM=xcb",
+    /* SDL needs to be able to talk to the system bus */
+    "--system-talk-name=org.freedesktop.DBus"
   ],
   "modules": [
     {


### PR DESCRIPTION
I was getting this assert:

process 2: arguments to dbus_connection_ref() were incorrect, assertion "connection->generation == _dbus_current_generation" failed in file dbus-connection.c line 2686.
This is normally a bug in some application using the D-Bus library.
  D-Bus not built with -rdynamic so unable to print a backtrace

This is due to SDL calling dbus_shutdown() if it fails to open the
system bus, affecting all other users of dbus in the process (in
particular the Qt one).

To fix this we grant the app access to org.freedesktop.DBus which is
safe, but triggers the creation of a dbus proxy for the system bus.