### PR TITLE
Update to 0.8.0

### DIFF
--- a/appdata.xml
+++ b/appdata.xml
@@ -20,7 +20,7 @@
     <screenshot>https://raw.githubusercontent.com/flathub/io.mgba.mGBA/master/screenshots/3.png</screenshot>
   </screenshots>
   <releases>
-    <release version="0.7.3" date="2019-09-15"/>
+    <release version="0.8.0" date="2020-01-22"/>
   </releases>
   <updatecontact>b@bpiotrowski.pl</updatecontact>
 </application>

--- a/io.mgba.mGBA.json
+++ b/io.mgba.mGBA.json
@@ -2,7 +2,7 @@
   "app-id": "io.mgba.mGBA",
   "runtime": "org.kde.Platform",
   "sdk": "org.kde.Sdk",
-  "runtime-version": "5.12",
+  "runtime-version": "5.13",
   "command": "mgba-qt",
   "rename-desktop-file": "mgba-qt.desktop",
   "rename-icon": "mgba",
@@ -29,8 +29,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/mgba-emu/mgba/archive/0.7.3.tar.gz",
-          "sha256": "6d5e8ab6f87d3d9fa85af2543db838568dbdfcecd6797f8153f1b3a10b4a8bdd"
+          "url": "https://github.com/mgba-emu/mgba/archive/0.8.0.tar.gz",
+          "sha256": "77da9416cb60fed10a35feb5d9b5b951cd0187c00c367a1f4d60ffc1b659c6dd"
         },
         {
           "type": "file",


### PR DESCRIPTION
I also updated the runtime version to 5.13, I have used a locally-built 0.8-b1 (with 5.13) for a couple of months, with no apparent problems.