### PR TITLE
Revert "Add `--socket=wayland` to the manifest"

### DIFF
--- a/io.mgba.mGBA.json
+++ b/io.mgba.mGBA.json
@@ -11,8 +11,7 @@
     "--device=all",
     "--filesystem=host:rw",
     "--socket=pulseaudio",
-    "--socket=fallback-x11",
-    "--socket=wayland",
+    "--socket=x11",
     "--share=network",
     /* SDL needs to be able to talk to UPower */
     "--system-talk-name=org.freedesktop.UPower",


### PR DESCRIPTION
Reverts flathub/io.mgba.mGBA#26

It was causing issues on plasma wayland, see https://github.com/flathub/io.mgba.mGBA/pull/26#issuecomment-910490458