### PR TITLE
Update to 0.10.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/appdata.xml
+++ b/appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <application>
-  <id type="desktop">mgba-qt.desktop</id>
+  <id type="desktop">io.mgba.mGBA.desktop</id>
   <name>mGBA</name>
   <summary>Nintendo Game Boy Advance Emulator</summary>
   <metadata_license>CC0-1.0</metadata_license>

--- a/appdata.xml
+++ b/appdata.xml
@@ -20,7 +20,7 @@
     <screenshot>https://raw.githubusercontent.com/flathub/io.mgba.mGBA/master/screenshots/3.png</screenshot>
   </screenshots>
   <releases>
-    <release version="0.9.3" date="2021-12-17"/>
+    <release version="0.10.0" date="2022-10-11"/>
   </releases>
   <updatecontact>b@bpiotrowski.pl</updatecontact>
 </application>

--- a/io.mgba.mGBA.json
+++ b/io.mgba.mGBA.json
@@ -4,8 +4,6 @@
   "sdk": "org.kde.Sdk",
   "runtime-version": "5.15-21.08",
   "command": "mgba-qt",
-  "rename-desktop-file": "mgba-qt.desktop",
-  "rename-icon": "mgba",
   "rename-appdata-file": "mgba.appdata.xml",
   "finish-args": [
     "--device=all",
@@ -19,6 +17,7 @@
     "--talk-name=org.freedesktop.ScreenSaver"
   ],
   "modules": [
+    "shared-modules/lua5.4/lua-5.4.json",
     {
       "name": "mgba",
       "buildsystem": "cmake-ninja",
@@ -32,8 +31,13 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/mgba-emu/mgba/archive/0.9.3.tar.gz",
-          "sha256": "692ff0ac50e18380df0ff3ee83071f9926715200d0dceedd9d16a028a59537a0"
+          "url": "https://github.com/mgba-emu/mgba/archive/0.10.0.tar.gz",
+          "sha256": "e2d66d9ce7c51b1ef3b339b04e871287bf166f6a1d7125ef112dbf53ab8bbd48",
+          "x-checker-data": {
+            "type": "anitya",
+            "project-id": 141675,
+            "url-template": "https://github.com/mgba-emu/mgba/archive/$version.tar.gz"
+          }
         },
         {
           "type": "file",

--- a/io.mgba.mGBA.json
+++ b/io.mgba.mGBA.json
@@ -23,7 +23,8 @@
       "buildsystem": "cmake-ninja",
       "config-opts": [
         "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_LIBDIR=lib"
+        "-DCMAKE_INSTALL_LIBDIR=lib",
+        "-DUSE_EPOXY=OFF"
       ],
       "build-commands": [
         "install -Dm644 appdata.xml /app/share/appdata/mgba.appdata.xml"


### PR DESCRIPTION
The shared modules submodule is used to build lua, needed for the new scripting support.

This also adds an `x-checker-data` entry.