### PR TITLE
Add `--socket=wayland` to the manifest

### DIFF
--- a/io.mgba.mGBA.json
+++ b/io.mgba.mGBA.json
@@ -9,7 +9,8 @@
     "--device=all",
     "--filesystem=host:rw",
     "--socket=pulseaudio",
-    "--socket=x11",
+    "--socket=fallback-x11",
+    "--socket=wayland",
     "--share=network",
     /* SDL needs to be able to talk to UPower */
     "--system-talk-name=org.freedesktop.UPower",


### PR DESCRIPTION
This is the same as #26, now that mGBA 0.10.0 fixed the compatibility issues with wayland.

Confirmed working on:
- Fedora 36 (Gnome and KDE)
- openSUSE Tumbleweed (KDE)
- Ubuntu 22.04 (Gnome)