### PR TITLE
Re-enable the BUILD_SDL build flags

### DIFF
--- a/io.mgba.mGBA.json
+++ b/io.mgba.mGBA.json
@@ -5,6 +5,7 @@
     "runtime-version": "5.15-23.08",
     "command": "mgba-qt",
     "cleanup": [
+        "/bin/mgba",
         "/include",
         "/share/doc",
         "/share/man"
@@ -27,7 +28,6 @@
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DCMAKE_INSTALL_LIBDIR=lib",
-                "-DBUILD_SDL=OFF",
                 "-DUSE_EPOXY=OFF"
             ],
             "build-commands": [


### PR DESCRIPTION
Disabling it caused the controllers tab in the settings window to disappear (although pre-configured controllers were working fine) as well as the default SDL audio driver (audio was not affected because Qt Multimedia is used as a fallback)

Manually delete the sdl frontend in the cleanup phase

Fixes #41